### PR TITLE
Allow J-LINK uploads to specify firmware offset

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -182,7 +182,7 @@ elif upload_protocol.startswith("jlink"):
         if not isdir(build_dir):
             makedirs(build_dir)
         script_path = join(build_dir, "upload.jlink")
-        commands = ["h", "loadbin %s,0x0" % source, "r", "q"]
+        commands = ["h", "loadbin %s, %s" % (source, env.BoardConfig().get("upload.offset_address", "0x0")), "r", "q"]
         with open(script_path, "w") as fp:
             fp.write("\n".join(commands))
         return script_path


### PR DESCRIPTION
Allow J-LINK uploads to flash at an offset into the space. This allow flashing firmware through the J-Link without destroying a bootloader which may exist.

To utilize this, something like the following can be added to a platformio.ini environment:
```
debug_tool = jlink
upload_protocol = jlink
board_upload.offset_address = 0x00004000
```